### PR TITLE
Adding CircleCI Integration for CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
       - persist_to_workspace:
           root: /home/circleci/project
           paths:
-            - *
+            - /*
 
   install-kernel-module:
     description: "Installs Kernel Module"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,24 @@ commands:
       - run:
           name: Compile Kernel Module
           command: make modules << parameters.build-args >> NV_VERBOSE=<< parameters.NV_VERBOSE >> DEBUG=<< parameters.DEBUG >>
-      - store_artifacts:
-          path: test-results
+      - persist_to_workspace:
+          root: /home/circleci/project
+          paths:
+            - *
+
+  install-kernel-module:
+    description: "Installs Kernel Module"
+    parameters:
+      build-args:
+        type: string
+        default: "-j`nproc`"
+    steps:
+      - attach_workspace:
+          at: /home/circleci/project
+      - run: ls -lah /home/circleci/project/
+      - run:
+          name: Compile Kernel Module
+          command: make modules_install << parameters.build-args >>
 
 
 executors:
@@ -44,11 +60,25 @@ jobs:
       - build-kernel-module:
           build-args: "-j`nproc`"
 
+  install:
+    parameters:
+      architecture:
+        type: executor
+    executor: << parameters.architecture >>
+    steps:
+      - build-kernel-module:
+          build-args: "-j`nproc`"
+
 workflows:
   multi-arch-build:
     jobs:
       - build:
           name: "Building << matrix.architecture >> Kernel Module"
+          matrix:
+            parameters:
+              architecture: ["arm64", "amd64"]
+      - install:
+          name: "Installing << matrix.architecture >> Kernel Module"
           matrix:
             parameters:
               architecture: ["arm64", "amd64"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,15 @@ commands:
       - run:
           name: Compile Kernel Module
           command: make modules << parameters.build-args >> NV_VERBOSE=<< parameters.NV_VERBOSE >> DEBUG=<< parameters.DEBUG >>
+      - run:
+          name: "Move Compiled Files to Temp Directory"
+          command: |
+            mkdir -p /tmp/kernel-open
+            cp -r kernel-open/* /tmp/kernel-open/
       - persist_to_workspace:
-          root: /home/circleci/project
+          root: /tmp
           paths:
-            - /*
+            - kernel-open/*
 
   install-kernel-module:
     description: "Installs Kernel Module"
@@ -30,11 +35,15 @@ commands:
         type: string
         default: "-j`nproc`"
     steps:
+      - checkout
       - attach_workspace:
-          at: /home/circleci/project
-      - run: ls -lah /home/circleci/project/
+          at: /tmp
       - run:
-          name: Compile Kernel Module
+          name: "Copy over Compiled Files from Temp Directory"
+          command: cp -r /tmp/kernel-open/* kernel-open/
+      - run: ls -lah kernel-open/
+      - run:
+          name: Install Kernel Module
           command: make modules_install << parameters.build-args >>
 
 
@@ -82,3 +91,5 @@ workflows:
           matrix:
             parameters:
               architecture: ["arm64", "amd64"]
+          requires:
+            - "Building << matrix.architecture >> Kernel Module"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
   install-kernel-module:
     description: "Installs Kernel Module"
     parameters:
-      build-args:
+      install-args:
         type: string
         default: "-j`nproc`"
     steps:
@@ -44,7 +44,7 @@ commands:
       - run: ls -lah kernel-open/
       - run:
           name: Install Kernel Module
-          command: make modules_install << parameters.build-args >>
+          command: make modules_install << parameters.install-args >>
 
 
 executors:
@@ -75,8 +75,8 @@ jobs:
         type: executor
     executor: << parameters.architecture >>
     steps:
-      - build-kernel-module:
-          build-args: "-j`nproc`"
+      - install-kernel-module:
+          install-args: "-j`nproc`"
 
 workflows:
   multi-arch-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
       - run: ls -lah kernel-open/
       - run:
           name: Install Kernel Module
-          command: make modules_install << parameters.install-args >>
+          command: sudo make modules_install << parameters.install-args >>
 
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,54 @@
+version: 2.1
+
+commands:
+  build-kernel-module:
+    description: "Builds Kernel Module"
+    parameters:
+      build-args:
+        type: string
+        default: "-j`nproc`"
+      NV_VERBOSE:
+        type: string
+        default: "0"
+      DEBUG:
+        type: string
+        default: "0"
+    steps:
+      - checkout
+      - run:
+          name: Compile Kernel Module
+          command: make modules << parameters.build-args >> NV_VERBOSE=<< parameters.NV_VERBOSE >> DEBUG=<< parameters.DEBUG >>
+      - store_artifacts:
+          path: test-results
+
+
+executors:
+  arm64:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: arm.medium
+
+  amd64:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: medium
+
+
+jobs:
+  build:
+    parameters:
+      architecture:
+        type: executor
+    executor: << parameters.architecture >>
+    steps:
+      - build-kernel-module:
+          build-args: "-j`nproc`"
+
+workflows:
+  multi-arch-build:
+    jobs:
+      - build:
+          name: "Building << matrix.architecture >> Kernel Module"
+          matrix:
+            parameters:
+              architecture: ["arm64", "amd64"]


### PR DESCRIPTION
Added CircleCI to handle CI/CD needs. Currently the workflow builds the kernel modules on both `arm64` and `amd64`. After building the kernel modules, it installs the newly made kernel modules on both architectures as well. 